### PR TITLE
Handle boolean config settings

### DIFF
--- a/sale_stock_restrict/models/res_config_settings.py
+++ b/sale_stock_restrict/models/res_config_settings.py
@@ -19,7 +19,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 #
 #############################################################################
-from odoo import api, fields, models
+from odoo import api, fields, models, tools
 
 
 class ResConfigSettings(models.TransientModel):
@@ -39,7 +39,9 @@ class ResConfigSettings(models.TransientModel):
         """Function to take values from the fields"""
         res = super().get_values()
         params = self.env['ir.config_parameter'].sudo().get_param
-        product_restriction = params('sale_stock_restrict.product_restriction')
+        product_restriction = tools.str2bool(
+            params('sale_stock_restrict.product_restriction')
+        )
         check_stock = params('sale_stock_restrict.check_stock')
         res.update(
             product_restriction=product_restriction,

--- a/sale_stock_restrict/models/sale_order.py
+++ b/sale_stock_restrict/models/sale_order.py
@@ -19,7 +19,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 #
 #############################################################################
-from odoo import api, fields, models
+from odoo import api, fields, models, tools
 from odoo.exceptions import ValidationError
 
 
@@ -38,8 +38,11 @@ class SaleOrderLine(models.Model):
     @api.onchange('product_id')
     def _onchange_product_id(self):
         """Function to set the value of the fields based on product."""
-        product_restriction = self.env['ir.config_parameter'].sudo().get_param(
-            'sale_stock_restrict.product_restriction')
+        product_restriction = tools.str2bool(
+            self.env['ir.config_parameter'].sudo().get_param(
+                'sale_stock_restrict.product_restriction'
+            )
+        )
         check_stock = self.env[
             'ir.config_parameter'].sudo().get_param(
             'sale_stock_restrict.check_stock')
@@ -68,9 +71,11 @@ class SaleOrder(models.Model):
         res = super().action_confirm()
         low_qty = ["Can't confirm the sale order due to: \n"]
         for rec in self.order_line:
-            product_restriction = self.env[
-                'ir.config_parameter'].sudo().get_param(
-                'sale_stock_restrict.product_restriction')
+            product_restriction = tools.str2bool(
+                self.env['ir.config_parameter'].sudo().get_param(
+                    'sale_stock_restrict.product_restriction'
+                )
+            )
             check_stock = self.env[
                 'ir.config_parameter'].sudo().get_param(
                 'sale_stock_restrict.check_stock')


### PR DESCRIPTION
## Summary
- ensure boolean conversion when reading settings
- fix product restriction checks using tools.str2bool

## Testing
- `pytest -q`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685f6d08c6a0833093c0766eb58caf2d