### PR TITLE
Refactor sale order confirmation

### DIFF
--- a/sale_stock_restrict/views/sale_order.xml
+++ b/sale_stock_restrict/views/sale_order.xml
@@ -11,11 +11,6 @@
                 <field name="qty_available"/>
                 <field name="forecast_quantity"/>
             </xpath>
-            <xpath expr="//field[@name='payment_term_id']"
-                   position="after">
-                <field name="onhand_check" invisible="True"/>
-                <field name="forecast_check" invisible="True"/>
-            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## Summary
- adjust stock restriction logic in `SaleOrder.action_confirm`
- drop temporary fields from views

## Testing
- `pytest -q`
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6de8f270833089d73f95a88c4516