### PR TITLE
Apply isort and black

### DIFF
--- a/sale_stock_restrict/__manifest__.py
+++ b/sale_stock_restrict/__manifest__.py
@@ -20,24 +20,24 @@
 #
 #############################################################################
 {
-    'name': 'Sale Stock Restrict',
-    'version': '18.0.1.0.0',
-    'category': 'Sales',
-    'summary': 'Module helps to restrict out of stock products',
-    'description': """This module helps manage out-of-stock products based on 
+    "name": "Sale Stock Restrict",
+    "version": "18.0.1.0.0",
+    "category": "Sales",
+    "summary": "Module helps to restrict out of stock products",
+    "description": """This module helps manage out-of-stock products based on 
     on-hand or forecast quantity.""",
-    'author': 'Cybrosys Techno solutions',
-    'company': 'Cybrosys Techno Solutions',
-    'maintainer': 'Cybrosys Techno Solutions',
-    'website': 'https://www.cybrosys.com',
-    'depends': ['base', 'sale_management', 'stock', 'account','website_sale'],
-    'data': [
-        'views/res_config_settings_views.xml',
-        'views/sale_order.xml',
+    "author": "Cybrosys Techno solutions",
+    "company": "Cybrosys Techno Solutions",
+    "maintainer": "Cybrosys Techno Solutions",
+    "website": "https://www.cybrosys.com",
+    "depends": ["base", "sale_management", "stock", "account", "website_sale"],
+    "data": [
+        "views/res_config_settings_views.xml",
+        "views/sale_order.xml",
     ],
-    'images': ['static/description/banner.jpg'],
-    'license': 'AGPL-3',
-    'installable': True,
-    'auto_install': False,
-    'application': False,
+    "images": ["static/description/banner.jpg"],
+    "license": "AGPL-3",
+    "installable": True,
+    "auto_install": False,
+    "application": False,
 }

--- a/sale_stock_restrict/models/__init__.py
+++ b/sale_stock_restrict/models/__init__.py
@@ -19,5 +19,4 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 #
 #############################################################################
-from . import res_config_settings
-from . import sale_order
+from . import res_config_settings, sale_order

--- a/sale_stock_restrict/models/res_config_settings.py
+++ b/sale_stock_restrict/models/res_config_settings.py
@@ -24,35 +24,40 @@ from odoo import api, fields, models, tools
 
 class ResConfigSettings(models.TransientModel):
     """Class to add fields and functions in settings"""
-    _inherit = 'res.config.settings'
+
+    _inherit = "res.config.settings"
 
     product_restriction = fields.Boolean(
-        string='Out Of Stock Product Restriction',
-        help='Enable this to restrict the out of stock product')
+        string="Out Of Stock Product Restriction",
+        help="Enable this to restrict the out of stock product",
+    )
     check_stock = fields.Selection(
-        [('on_hand_quantity', 'On Hand Quantity'),
-         ('forecast_quantity', 'Forecast Quantity')], string="Based On",
-        help='Choose the type of restriction')
+        [
+            ("on_hand_quantity", "On Hand Quantity"),
+            ("forecast_quantity", "Forecast Quantity"),
+        ],
+        string="Based On",
+        help="Choose the type of restriction",
+    )
 
     @api.model
     def get_values(self):
         """Function to take values from the fields"""
         res = super().get_values()
-        params = self.env['ir.config_parameter'].sudo().get_param
+        params = self.env["ir.config_parameter"].sudo().get_param
         product_restriction = tools.str2bool(
-            params('sale_stock_restrict.product_restriction')
+            params("sale_stock_restrict.product_restriction")
         )
-        check_stock = params('sale_stock_restrict.check_stock')
-        res.update(
-            product_restriction=product_restriction,
-            check_stock=check_stock
-        )
+        check_stock = params("sale_stock_restrict.check_stock")
+        res.update(product_restriction=product_restriction, check_stock=check_stock)
         return res
 
     def set_values(self):
         """Function to set the values in the fields"""
         super().set_values()
-        self.env['ir.config_parameter'].sudo().set_param(
-            'sale_stock_restrict.product_restriction', self.product_restriction)
-        self.env['ir.config_parameter'].sudo().set_param(
-            'sale_stock_restrict.check_stock', self.check_stock)
+        self.env["ir.config_parameter"].sudo().set_param(
+            "sale_stock_restrict.product_restriction", self.product_restriction
+        )
+        self.env["ir.config_parameter"].sudo().set_param(
+            "sale_stock_restrict.check_stock", self.check_stock
+        )


### PR DESCRIPTION
## Summary
- format module manifest
- compact imports in sale_stock_restrict.models
- apply consistent quoting and line breaks in models

## Testing
- `isort .`
- `black . --color`
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7059f7908330bc57de95df51fe46