### PR TITLE
Add custom warehouse access restriction module

### DIFF
--- a/user_access_restrict/__init__.py
+++ b/user_access_restrict/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/user_access_restrict/__manifest__.py
+++ b/user_access_restrict/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "User Access Restrict",
+    "version": "18.0.1.0.0",
+    "category": "Warehouse",
+    "summary": "Dynamic warehouse based access control",
+    "description": "Manage user permissions per warehouse using custom access types.",
+    "author": "Cybrosys Techno solutions",
+    "company": "Cybrosys Techno Solutions",
+    "maintainer": "Cybrosys Techno Solutions",
+    "website": "https://www.cybrosys.com",
+    "depends": ["stock", "sale_management", "purchase"],
+    "data": [
+        "security/user_groups.xml",
+        "security/ir.model.access.csv",
+        "security/record_rules.xml",
+        "views/res_users_views.xml",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/user_access_restrict/models/__init__.py
+++ b/user_access_restrict/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_users

--- a/user_access_restrict/models/res_users.py
+++ b/user_access_restrict/models/res_users.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Cybrosys Technologies Pvt. Ltd.
+#
+#    Copyright (C) 2024-TODAY Cybrosys Technologies(<https://www.cybrosys.com>)
+#    Author: Cybrosys Techno Solutions(<https://www.cybrosys.com>)
+#
+#    You can modify it under the terms of the GNU AFFERO
+#    GENERAL PUBLIC LICENSE (AGPL v3), Version 3.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU AFFERO GENERAL PUBLIC LICENSE (AGPL v3) for more details.
+#
+#    You should have received a copy of the GNU AFFERO GENERAL PUBLIC LICENSE
+#    (AGPL v3) along with this program.
+#    If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResUsers(models.Model):
+    """Extend res.users with custom access type and allowed warehouses."""
+
+    _inherit = "res.users"
+
+    access_type = fields.Selection(
+        [
+            ("custom_manager", "مدير مخصص"),
+            ("custom_user", "مستخدم مخصص"),
+        ],
+        string="نوع الوصول",
+    )
+    allowed_warehouse_ids = fields.Many2many(
+        "stock.warehouse", string="المستودعات المصرح بها"
+    )
+
+    @api.constrains("access_type", "allowed_warehouse_ids")
+    def _check_allowed_warehouses(self):
+        """Ensure at least one warehouse is set when access type defined."""
+        for user in self:
+            if user.access_type and not user.allowed_warehouse_ids:
+                raise ValidationError("يجب تحديد مستودع واحد على الأقل")
+
+    def write(self, vals):
+        """Ensure group assignment follows access type."""
+        res = super().write(vals)
+        if "access_type" in vals:
+            for user in self:
+                user._update_groups()
+        return res
+
+    def create(self, vals_list):
+        users = super().create(vals_list)
+        users._update_groups()
+        return users
+
+    def _update_groups(self):
+        """Assign groups based on access type."""
+        group_manager = self.env.ref(
+            "user_access_restrict.group_user_access_custom_manager",
+            raise_if_not_found=False,
+        )
+        group_user = self.env.ref(
+            "user_access_restrict.group_user_access_custom_user",
+            raise_if_not_found=False,
+        )
+        for user in self:
+            if group_manager and group_user:
+                if user.access_type == "custom_manager":
+                    user.write(
+                        {"groups_id": [(3, group_user.id), (4, group_manager.id)]}
+                    )
+                elif user.access_type == "custom_user":
+                    user.write(
+                        {"groups_id": [(3, group_manager.id), (4, group_user.id)]}
+                    )
+                else:
+                    user.write(
+                        {"groups_id": [(3, group_manager.id), (3, group_user.id)]}
+                    )

--- a/user_access_restrict/security/ir.model.access.csv
+++ b/user_access_restrict/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/user_access_restrict/security/record_rules.xml
+++ b/user_access_restrict/security/record_rules.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Stock Picking -->
+    <record id="rule_stock_picking_manager" model="ir.rule">
+        <field name="name">Stock Picking Manager</field>
+        <field name="model_id" ref="stock.model_stock_picking"/>
+        <field name="domain_force">['|',('picking_type_id.warehouse_id','in',user.allowed_warehouse_ids.ids),('picking_type_id.warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_manager'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="rule_stock_picking_user" model="ir.rule">
+        <field name="name">Stock Picking User</field>
+        <field name="model_id" ref="stock.model_stock_picking"/>
+        <field name="domain_force">['|',('picking_type_id.warehouse_id','in',user.allowed_warehouse_ids.ids),('picking_type_id.warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <!-- Stock Location -->
+    <record id="rule_stock_location_manager" model="ir.rule">
+        <field name="name">Stock Location Manager</field>
+        <field name="model_id" ref="stock.model_stock_location"/>
+        <field name="domain_force">['|',('warehouse_id','in',user.allowed_warehouse_ids.ids),('warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_manager'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="rule_stock_location_user" model="ir.rule">
+        <field name="name">Stock Location User</field>
+        <field name="model_id" ref="stock.model_stock_location"/>
+        <field name="domain_force">['|',('warehouse_id','in',user.allowed_warehouse_ids.ids),('warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <!-- Stock Move -->
+    <record id="rule_stock_move_manager" model="ir.rule">
+        <field name="name">Stock Move Manager</field>
+        <field name="model_id" ref="stock.model_stock_move"/>
+        <field name="domain_force">['|',('move_line_ids.location_id.warehouse_id','in',user.allowed_warehouse_ids.ids),('move_line_ids.location_id.warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_manager'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="rule_stock_move_user" model="ir.rule">
+        <field name="name">Stock Move User</field>
+        <field name="model_id" ref="stock.model_stock_move"/>
+        <field name="domain_force">['|',('move_line_ids.location_id.warehouse_id','in',user.allowed_warehouse_ids.ids),('move_line_ids.location_id.warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <!-- Stock Quant -->
+    <record id="rule_stock_quant_manager" model="ir.rule">
+        <field name="name">Stock Quant Manager</field>
+        <field name="model_id" ref="stock.model_stock_quant"/>
+        <field name="domain_force">['|',('location_id.warehouse_id','in',user.allowed_warehouse_ids.ids),('location_id.warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_manager'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="rule_stock_quant_user" model="ir.rule">
+        <field name="name">Stock Quant User</field>
+        <field name="model_id" ref="stock.model_stock_quant"/>
+        <field name="domain_force">['|',('location_id.warehouse_id','in',user.allowed_warehouse_ids.ids),('location_id.warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <!-- Sale Order -->
+    <record id="rule_sale_order_manager" model="ir.rule">
+        <field name="name">Sale Order Manager</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="domain_force">['|',('warehouse_id','in',user.allowed_warehouse_ids.ids),('warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_manager'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="rule_sale_order_user" model="ir.rule">
+        <field name="name">Sale Order User</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="domain_force">['|',('warehouse_id','in',user.allowed_warehouse_ids.ids),('warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <!-- Purchase Order -->
+    <record id="rule_purchase_order_manager" model="ir.rule">
+        <field name="name">Purchase Order Manager</field>
+        <field name="model_id" ref="purchase.model_purchase_order"/>
+        <field name="domain_force">['|',('picking_type_id.warehouse_id','in',user.allowed_warehouse_ids.ids),('picking_type_id.warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_manager'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="rule_purchase_order_user" model="ir.rule">
+        <field name="name">Purchase Order User</field>
+        <field name="model_id" ref="purchase.model_purchase_order"/>
+        <field name="domain_force">['|',('picking_type_id.warehouse_id','in',user.allowed_warehouse_ids.ids),('picking_type_id.warehouse_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('user_access_restrict.group_user_access_custom_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+</odoo>

--- a/user_access_restrict/security/user_groups.xml
+++ b/user_access_restrict/security/user_groups.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="group_user_access_custom_manager" model="res.groups">
+        <field name="name">Custom Manager</field>
+        <field name="category_id" ref="base.module_category_inventory"/>
+    </record>
+    <record id="group_user_access_custom_user" model="res.groups">
+        <field name="name">Custom User</field>
+        <field name="category_id" ref="base.module_category_inventory"/>
+    </record>
+</odoo>

--- a/user_access_restrict/views/res_users_views.xml
+++ b/user_access_restrict/views/res_users_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_users_form_inherit_user_access" model="ir.ui.view">
+        <field name="name">res.users.form.user.access.restrict</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/notebook" position="inside">
+                <page string="Access Restrict">
+                    <group>
+                        <field name="access_type"/>
+                        <field name="allowed_warehouse_ids" attrs="{'invisible': [('access_type','=',False)]}"/>
+                    </group>
+                    <label string="\nنوع الوصول \u0627\u0644\u0645\u062f\u064a\u0631 \u064a\u0645\u0644\u0643 \u0635\u0644\u0627\u062d\u064a\u0627\u062a \u0643\u0627\u0645\u0644\u0629 \u0648\u0627\u0644\u0645\u0633\u062a\u062e\u062f\u0645 \u0641\u0642\u0637 \u0642\u0631\u0627\u0621\u0629 \u0648\u062a\u0639\u062f\u064a\u0644"/>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add `user_access_restrict` module to manage user access by allowed warehouses
- include new fields on users and record rules for stock, sale, and purchase models
- provide UI to manage access type and warehouses

## Testing
- `pytest -q` *(no tests found)*
- `pylint user_access_restrict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f73c4d32483308fb05e65361a6e7d