### PR TITLE
Add newline at EOF for res_users

### DIFF
--- a/user_access_restrict/models/res_users.py
+++ b/user_access_restrict/models/res_users.py
@@ -83,3 +83,4 @@ class ResUsers(models.Model):
                     user.write(
                         {"groups_id": [(3, group_manager.id), (3, group_user.id)]}
                     )
+


### PR DESCRIPTION
## Summary
- ensure `res_users.py` ends with a newline

## Testing
- `python3 -m py_compile user_access_restrict/models/res_users.py`
- `flake8 user_access_restrict/models/res_users.py` *(fails: command not found)*
- `pylint user_access_restrict/models/res_users.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f78f4ca2c833096312d21bbc809e5