### PR TITLE
Update installation docs links

### DIFF
--- a/sale_stock_restrict/README.rst
+++ b/sale_stock_restrict/README.rst
@@ -8,7 +8,7 @@ Sale Stock Restrict
 
 Installation
 ============
-- www.odoo.com/documentation/17.0/setup/install.html
+ - https://www.odoo.com/documentation/18.0/setup/install.html
 - Install our custom addon
 
 License

--- a/user_access_restrict/README.rst
+++ b/user_access_restrict/README.rst
@@ -27,7 +27,7 @@ Record Rules
 
 Installation
 ============
-- www.odoo.com/documentation/17.0/setup/install.html
+ - https://www.odoo.com/documentation/18.0/setup/install.html
 - Install our custom addon
 
 License


### PR DESCRIPTION
## Summary
- update references to installation docs to point to Odoo 18

## Testing
- `python -m flake8` *(fails: No module named flake8)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f7dc892a48330bb7ec58ca51e4e73