### PR TITLE
Fix product type check in sale_order confirm

### DIFF
--- a/sale_stock_restrict/models/sale_order.py
+++ b/sale_stock_restrict/models/sale_order.py
@@ -81,7 +81,7 @@ class SaleOrder(models.Model):
             if (
                 product_restriction
                 and not self.website_id
-                and rec.product_id.type == "consu"
+                and rec.product_id.type == "product"
             ):
                 if (
                     check_stock == "on_hand_quantity"

--- a/tests/tests/test_modules.py
+++ b/tests/tests/test_modules.py
@@ -1,4 +1,5 @@
 from odoo.tests.common import TransactionCase
+from odoo.exceptions import ValidationError
 
 
 class TestRestrictModules(TransactionCase):
@@ -7,6 +8,46 @@ class TestRestrictModules(TransactionCase):
             [("name", "=", "sale_stock_restrict")], limit=1
         )
         self.assertEqual(module.state, "installed")
+
+    def test_stock_product_restriction(self):
+        """Confirming an order with insufficient stockable product should fail."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "sale_stock_restrict.product_restriction", True
+        )
+        self.env["ir.config_parameter"].sudo().set_param(
+            "sale_stock_restrict.check_stock", "on_hand_quantity"
+        )
+
+        product = self.env["product.product"].create(
+            {
+                "name": "Restricted Product",
+                "type": "product",
+                "list_price": 10.0,
+            }
+        )
+
+        partner = self.env.ref("base.res_partner_3")
+
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": 1,
+                            "name": product.name,
+                            "price_unit": product.list_price,
+                        },
+                    )
+                ],
+            }
+        )
+
+        with self.assertRaises(ValidationError):
+            order.action_confirm()
 
     def test_user_access_restrict_installed(self):
         module = self.env["ir.module.module"].search(


### PR DESCRIPTION
## Summary
- restrict confirmation based on stockable products
- add a TransactionCase test covering the restriction logic

## Testing
- `python -m py_compile sale_stock_restrict/models/sale_order.py tests/tests/test_modules.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_685f8640437083308fd7cfc57338293d