### PR TITLE
Update test prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ Follow the standard Odoo installation guide: <https://www.odoo.com/documentation
 After installing Odoo, add these modules to your addons path and install them from the Apps menu.
 
 ## Running Tests
-Tests require a working Odoo environment. Once Odoo and the modules' dependencies are installed, run:
+Tests rely on an existing Odoo 18.0 installation. You can either install Odoo locally from source or use a Docker container such as `odoo:18.0`.
+
+Install the Python requirements with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Once Odoo is available and dependencies are installed, run:
 
 ```bash
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+flake8


### PR DESCRIPTION
## Summary
- update README with instructions for installing dependencies
- add a `requirements.txt` file to list Python packages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f881565d88330925cc916b69e154e