### PR TITLE
Add sale stock restriction module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ This repository provides two Odoo 18 modules to manage warehouse restrictions.
 ## Modules
 
 ### sale_stock_restrict
-Restricts confirming sale orders when products are not available. The check can be based on on-hand or forecasted quantities.
+Restricts confirming sale orders when products are not available.
+
+- Toggle the behaviour with the `sale_stock_restrict.product_restriction` setting.
+- Use `sale_stock_restrict.check_stock` to decide whether on-hand or forecast quantities are evaluated.
 
 ### user_access_restrict
 Adds warehouse-based access control. Users can be assigned access to specific warehouses with custom roles (manager or user) that determine permitted operations.

--- a/sale_stock_restrict/README.rst
+++ b/sale_stock_restrict/README.rst
@@ -1,0 +1,8 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+Sale Stock Restrict
+===================
+* Prevents confirming sale orders when products are not available.
+* Administrator can choose between checking on-hand or forecast quantities using configuration settings.

--- a/sale_stock_restrict/__init__.py
+++ b/sale_stock_restrict/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_stock_restrict/__manifest__.py
+++ b/sale_stock_restrict/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Sale Stock Restrict",
+    "version": "18.0.1.0.0",
+    "category": "Sales",
+    "summary": "Restrict sale order confirmation based on available stock",
+    "description": "Prevent confirming sale orders when stock is insufficient.",
+    "author": "Cybrosys Techno solutions",
+    "company": "Cybrosys Techno Solutions",
+    "maintainer": "Cybrosys Techno Solutions",
+    "website": "https://www.cybrosys.com",
+    "depends": ["sale_management", "stock"],
+    "data": [
+        "security/ir.model.access.csv",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/sale_stock_restrict/models/__init__.py
+++ b/sale_stock_restrict/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_config_settings
+from . import sale_order

--- a/sale_stock_restrict/models/res_config_settings.py
+++ b/sale_stock_restrict/models/res_config_settings.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Configuration parameters for sale stock restriction."""
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    """Extend settings with stock restriction options."""
+
+    _inherit = "res.config.settings"
+
+    product_restriction = fields.Boolean(
+        string="Restrict Sale Order Confirmation",
+        config_parameter="sale_stock_restrict.product_restriction",
+    )
+    check_stock = fields.Selection(
+        [
+            ("on_hand_quantity", "On Hand Quantity"),
+            ("forecast_quantity", "Forecast Quantity"),
+        ],
+        default="on_hand_quantity",
+        config_parameter="sale_stock_restrict.check_stock",
+        string="Quantity Check Type",
+    )

--- a/sale_stock_restrict/models/sale_order.py
+++ b/sale_stock_restrict/models/sale_order.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Restrict confirming sale orders when stock is insufficient."""
+
+from odoo import _, models
+from odoo.exceptions import ValidationError
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def action_confirm(self):
+        """Check stock before confirming when restriction enabled."""
+        icp = self.env["ir.config_parameter"].sudo()
+        restrict = icp.get_param("sale_stock_restrict.product_restriction", default="False")
+        if restrict and restrict not in [False, "False", 0, "0"]:
+            check_type = icp.get_param(
+                "sale_stock_restrict.check_stock", default="on_hand_quantity"
+            )
+            for order in self:
+                product_quantities = {}
+                for line in order.order_line.filtered(lambda l: l.product_id.type == "product"):
+                    qty = product_quantities.get(line.product_id, 0) + line.product_uom_qty
+                    product_quantities[line.product_id] = qty
+                for product, qty_needed in product_quantities.items():
+                    available = (
+                        product.qty_available
+                        if check_type == "on_hand_quantity"
+                        else product.virtual_available
+                    )
+                    if available < qty_needed:
+                        raise ValidationError(
+                            _("Not enough quantity for %s") % product.display_name
+                        )
+        return super().action_confirm()

--- a/sale_stock_restrict/security/ir.model.access.csv
+++ b/sale_stock_restrict/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/tests/tests/test_modules.py
+++ b/tests/tests/test_modules.py
@@ -49,6 +49,36 @@ class TestRestrictModules(TransactionCase):
         with self.assertRaises(ValidationError):
             order.action_confirm()
 
+    def test_stock_product_restriction_disabled(self):
+        """When restriction disabled, confirmation should succeed."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "sale_stock_restrict.product_restriction", False
+        )
+
+        product = self.env["product.product"].create({"name": "Free Product", "type": "product"})
+
+        partner = self.env.ref("base.res_partner_3")
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": 1,
+                            "name": product.name,
+                            "price_unit": 0.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+        order.action_confirm()
+        self.assertEqual(order.state, "sale")
+
     def test_user_access_restrict_installed(self):
         module = self.env["ir.module.module"].search(
             [("name", "=", "user_access_restrict")], limit=1


### PR DESCRIPTION
## Summary
- add new sale_stock_restrict addon with config settings and stock checks
- update README with configuration details
- expand module tests

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_686736a8a62c833090a72bfa6831bc9f